### PR TITLE
Update main.py

### DIFF
--- a/mcp_sync/main.py
+++ b/mcp_sync/main.py
@@ -211,8 +211,11 @@ def handle_list_locations(config_manager):
 
     print("Registered config locations:")
     for location in locations:
-        print(f"  {location['name']} ({location['type']})")
-        print(f"    Path: {location['path']}")
+        name = location.get('name', 'Unnamed')
+        location_type = location.get('type', 'Unknown')
+        path = location.get('path', 'No path')
+        print(f"  {name} ({location_type})")
+        print(f"    Path: {path}")
 
 
 def handle_sync(sync_engine, args):


### PR DESCRIPTION
I cannot find the config_manager.py file. This is unusual and might indicate a missing or misplaced file.

Based on the error and the code I've seen, here are the likely causes of the error:

1. The get_locations() method is returning locations that do not have a 'type' key.
2. The configuration data structure is malformed.
3. There might be an issue with how locations are being registered or stored.

To diagnose this further, I recommend:

1. Check the implementation of config_manager.py or the method that populates the locations.
2. Verify the structure of your configuration files.
3. Add error handling in the handle_list_locations function to gracefully handle missing keys.

Here's a suggested code modification to handle this more robustly: The modification I've made adds robust error handling to the handle_list_locations function. Now, if a location is missing the 'type', 'name', or 'path' keys, it will use default values instead of raising an error.

To diagnose the root cause, I recommend checking the implementation of config_manager.get_locations(). This will help you understand why the location dictionaries might be missing the 'type' key.