### PR TITLE
Add inline parameter support for automation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,39 @@ wheels/
 
 # Virtual environments
 .venv
+venv/
+env/
+
+# IDE and editor files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# Type checking and linting
+.mypy_cache/
+.ruff_cache/
+.pytest_cache/
+.coverage
+htmlcov/
+.tox/
+
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Temporary files
+*.tmp
+*.temp
+*.log
+
+# Claude Code specific
 CLAUDE.md
 .claude/
 .serena

--- a/README.md
+++ b/README.md
@@ -85,9 +85,28 @@ uv pip install -e .
 - `mcp-sync sync --location <path>` - Sync specific location only
 
 ### Server Management
-- `mcp-sync add-server <name>` - Add MCP server to sync
-- `mcp-sync remove-server <name>` - Remove server from sync
+- `mcp-sync add-server <name>` - Add MCP server to sync (interactive prompts)
+- `mcp-sync add-server <name> --command <cmd> --args <args> --env <vars> --scope <global|project>` - Add server with inline parameters
+- `mcp-sync remove-server <name>` - Remove server from sync (interactive prompts)
+- `mcp-sync remove-server <name> --scope <global|project>` - Remove server with inline scope
 - `mcp-sync list-servers` - Show all managed servers
+
+**Adding Servers**: When adding a server, you need to provide:
+- **Command**: The executable to run (e.g., `python`, `npx`, `node`)
+- **Arguments**: Command-line arguments (comma-separated, optional)
+- **Environment**: Environment variables as `KEY=value` pairs (comma-separated, optional)
+- **Scope**: Whether to add to global config (synced everywhere) or project config (this project only)
+
+Interactive example:
+```bash
+mcp-sync add-server filesystem
+# Prompts for: scope, command, args, env vars
+```
+
+Automated example:
+```bash
+mcp-sync add-server filesystem --command npx --args "-y,@modelcontextprotocol/server-filesystem,/home/user/docs" --scope global
+```
 
 ### Project Management
 - `mcp-sync init` - Create project `.mcp.json`

--- a/mcp_sync/config.py
+++ b/mcp_sync/config.py
@@ -37,12 +37,12 @@ class ConfigManager:
         # Claude Desktop
         claude_path = self._get_platform_config_path("Claude", "claude_desktop_config.json")
         if claude_path.exists():
-            locations.append({"path": str(claude_path), "name": "claude-desktop"})
+            locations.append({"path": str(claude_path), "name": "claude-desktop", "type": "auto"})
 
         # Claude Code
         claude_code_path = Path.home() / ".claude/settings.json"
         if claude_code_path.exists():
-            locations.append({"path": str(claude_code_path), "name": "claude-code"})
+            locations.append({"path": str(claude_code_path), "name": "claude-code", "type": "auto"})
 
         return locations
 
@@ -51,13 +51,13 @@ class ConfigManager:
             "Code", "User/globalStorage/cline_mcp_settings.json"
         )
         if cline_path.exists():
-            return [{"path": str(cline_path), "name": "cline"}]
+            return [{"path": str(cline_path), "name": "cline", "type": "auto"}]
         return []
 
     def _get_vscode_locations(self) -> list[dict[str, str]]:
         vscode_path = self._get_platform_config_path("Code", "User/settings.json")
         if vscode_path.exists():
-            return [{"path": str(vscode_path), "name": "vscode-user"}]
+            return [{"path": str(vscode_path), "name": "vscode-user", "type": "auto"}]
         return []
 
     def _get_platform_config_path(self, app_name: str, subpath: str) -> Path:


### PR DESCRIPTION
## Summary
- Add inline parameter support to `add-server` and `remove-server` commands for automation
- Add `--auto-resolve` flag to `vacuum` command for non-interactive conflict resolution
- Update README with clear server configuration workflow and examples
- Improve .gitignore to exclude development tool caches

## Key Features
- **Automated server management**: `--command`, `--args`, `--env`, `--scope` flags for add-server
- **Scriptable removal**: `--scope` flag for remove-server
- **Non-interactive vacuum**: `--auto-resolve` for conflict resolution
- **Backwards compatible**: All existing interactive workflows still work

## Examples
```bash
# Automated server addition
mcp-sync add-server filesystem --command npx --args "-y,@modelcontextprotocol/server-filesystem,/tmp" --scope global

# Scriptable removal
mcp-sync remove-server filesystem --scope global

# Non-interactive vacuum
mcp-sync vacuum --auto-resolve first
```

## Use Cases
- CI/CD pipelines
- Setup scripts
- Docker containers
- Automated deployments

Addresses the Reddit comment about making server configuration clearer and enables automation workflows.