### PR TITLE
Add CLI tests and fix add-server parser

### DIFF
--- a/mcp_sync/main.py
+++ b/mcp_sync/main.py
@@ -48,7 +48,7 @@ def create_parser():
     # Server management
     add_server_parser = subparsers.add_parser("add-server", help="Add MCP server to sync")
     add_server_parser.add_argument("name", help="Server name")
-    add_server_parser.add_argument("--command", help="Command to run the server")
+    add_server_parser.add_argument("--cmd", dest="server_cmd", help="Command to run the server")
     add_server_parser.add_argument("--args", help="Command arguments (comma-separated)")
     add_server_parser.add_argument("--env", help="Environment variables (KEY=value,KEY2=value2)")
     add_server_parser.add_argument("--scope", choices=["global", "project"], help="Config scope")
@@ -262,7 +262,7 @@ def handle_add_server(sync_engine, args):
 
     try:
         # Check if inline parameters provided
-        if args.command and args.scope:
+        if args.server_cmd and args.scope:
             # Inline mode
             scope = args.scope
             config = _build_server_config_from_args(args)
@@ -283,7 +283,7 @@ def handle_add_server(sync_engine, args):
 
 def _build_server_config_from_args(args):
     """Build server config from inline command arguments"""
-    config = {"command": args.command}
+    config = {"command": args.server_cmd}
 
     if args.args:
         config["args"] = [arg.strip() for arg in args.args.split(",")]

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,18 @@
+from mcp_sync.main import handle_init
+
+
+def test_handle_init_creates_file(tmp_path, monkeypatch, capsys):
+    monkeypatch.chdir(tmp_path)
+    handle_init()
+    assert (tmp_path / ".mcp.json").exists()
+    out = capsys.readouterr().out
+    assert "Created .mcp.json" in out
+
+
+def test_handle_init_existing_file(tmp_path, monkeypatch, capsys):
+    cfg = tmp_path / ".mcp.json"
+    cfg.write_text("{}")
+    monkeypatch.chdir(tmp_path)
+    handle_init()
+    out = capsys.readouterr().out
+    assert ".mcp.json already exists" in out

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,44 @@
+import argparse
+
+from mcp_sync import main
+
+
+def test_create_parser_subcommands():
+    parser = main.create_parser()
+    commands = [
+        ("scan", []),
+        ("status", []),
+        ("diff", []),
+        ("add-location", ["path"]),
+        ("remove-location", ["path"]),
+        ("list-locations", []),
+        ("sync", []),
+        ("add-server", ["name"]),
+        ("remove-server", ["name"]),
+        ("list-servers", []),
+        ("vacuum", []),
+        ("init", []),
+        ("template", []),
+    ]
+    for cmd, extra in commands:
+        args = parser.parse_args([cmd] + extra)
+        assert args.command == cmd
+
+
+def test_build_server_config_from_args():
+    args = argparse.Namespace(server_cmd="python", args="a,b", env="A=1,B=2", scope=None)
+    config = main._build_server_config_from_args(args)
+    assert config == {
+        "command": "python",
+        "args": ["a", "b"],
+        "env": {"A": "1", "B": "2"},
+    }
+
+
+def test_get_effective_config_project_overrides():
+    status = {
+        "project_servers": {"s": {"command": "proj"}},
+        "global_servers": {"s": {"command": "glob"}},
+    }
+    cfg = main._get_effective_config("s", status)
+    assert cfg["command"] == "proj"

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1,0 +1,37 @@
+from mcp_sync.sync import SyncEngine
+
+
+class DummyConfig:
+    def __init__(self, locations):
+        self._locations = locations
+
+    def get_locations(self):
+        return self._locations
+
+    def get_global_config(self):
+        return {"mcpServers": {}}
+
+
+def test_get_sync_locations_filters(tmp_path):
+    locs = [
+        {"path": str(tmp_path / "g.json"), "name": "g", "scope": "global"},
+        {"path": str(tmp_path / "p.json"), "name": "p", "scope": "project"},
+        {"path": str(tmp_path / ".mcp.json"), "name": "proj", "scope": "project"},
+    ]
+    engine = SyncEngine(DummyConfig(locs))
+
+    all_locs = engine._get_sync_locations(None, False, False)
+    assert len(all_locs) == 2
+    assert all(loc["path"] != str(tmp_path / ".mcp.json") for loc in all_locs)
+
+    g_only = engine._get_sync_locations(None, True, False)
+    assert g_only == [locs[0]]
+
+    p_only = engine._get_sync_locations(None, False, True)
+    assert p_only == [locs[1]]
+
+    spec = engine._get_sync_locations(locs[1]["path"], False, False)
+    assert spec == [locs[1]]
+
+    missing = engine._get_sync_locations("/nope", False, False)
+    assert missing == []


### PR DESCRIPTION
## Summary
- avoid argparse dest conflict by renaming `--command` to `--cmd`
- parse inline server configuration with new `server_cmd` name
- test parser creation and helper functions
- cover project initialization and location filtering logic

## Testing
- `ruff format --check .`
- `ruff check .`
- `PYTHONPATH=. pytest -q`