### PR TITLE
Improve vacuum command

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,11 @@ cd mcp-sync
 - `mcp-sync remove-server <name> --scope <global|project>` - Remove server with inline scope
 - `mcp-sync list-servers` - Show all managed servers
 
+### Migration
+- `mcp-sync vacuum` - Import MCP servers from discovered configs
+  - `--auto-resolve <first|last>` choose conflict resolution automatically
+  - `--skip-existing` avoid overwriting servers already in global config
+
 **Adding Servers**: When adding a server, you need to provide:
 - **Command**: The executable to run (e.g., `python`, `npx`, `node`)
 - **Arguments**: Command-line arguments (comma-separated, optional)
@@ -221,6 +226,17 @@ uv pip install -e .
 uv run ruff check .     # Linting
 uv run ruff format .    # Formatting
 uv run pytest          # Tests (when available)
+```
+
+### Running Tests
+Tests require the package to be on `PYTHONPATH`. Either install it in editable mode:
+```bash
+uv pip install -e .
+uv run pytest
+```
+or set `PYTHONPATH` manually when invoking pytest:
+```bash
+PYTHONPATH=$PWD uv run pytest
 ```
 
 ## License

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,9 @@ target-version = "py312"
 select = ["E", "F", "W", "I", "N", "UP", "S", "B", "A", "C4", "PT"]
 ignore = ["S101"]  # Allow assert statements
 
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = ["S108"]  # Allow insecure temp file usage in tests
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"


### PR DESCRIPTION
## Summary
- implement `--auto-resolve` and `--skip-existing` options for vacuum
- add `skipped_servers` tracking to vacuum results
- document vacuum usage and test instructions
- add tests for auto-resolve and skipping existing servers

## Testing
- `PYTHONPATH=$PWD pytest -q`
- `ruff format mcp_sync tests`
- `ruff check mcp_sync tests`
